### PR TITLE
Smoke-test: call yarpdataplayer from yarpmanager

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/easy-peasy-robotics/web-contest-sandbox:latest
+image: ghcr.io/vvv-school/gitpod:latest
 ports:
 - port: 6080
   onOpen: notify

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The task at hand is to correctly detect a red ball from images from a dataset st
 
 The dataset is currently available on the provided virtual environment. Otherwise, it can be downloaded following these simple steps:
 ```sh
-cd $DATASETS_PATH
 $ wget http://www.icub.org/download/software/datasetplayer-demo/testData_20120803_095402.zip
 $ unzip testData_20120803_095402.zip
 ```
+Finally, create the env var `DATASETS_PATH` pointing to the location where you've unzipped the archieve.
 
 # [How to complete the assignment](https://github.com/vvv-school/vvv-school.github.io/blob/master/instructions/how-to-complete-assignments.md)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,19 @@
 Robot vision with OpenCV tutorial part two
-==========================
+==========================================
 
 <!--[![GitPitch](https://gitpitch.com/assets/badge.svg)](https://gitpitch.com/vvv-school/tutorial_yarp-opencv/master?grs=github&t=moon)
 -->
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/vvv-school/tutorial_yarp-opencv)
-
 
 This second tutorial will guide you through integrating YARP with OpenCV while getting live image streams.
 
 The task at hand is to correctly detect a red ball from images from a dataset streamed through a port.
 
 The dataset is currently available on the provided virtual machine. Otherwise it can be downloaded following these simple steps:
-```
-cd $ROBOT_CODE
-$ mkdir datasets && cd datasets
+```sh
+cd $DATASETS_PATH
 $ wget http://www.icub.org/download/software/datasetplayer-demo/testData_20120803_095402.zip
 $ unzip testData_20120803_095402.zip
 ```
-Tutorial
-========
-
-We aim to walk you through the steps contained in this code that will let allow to complete the task at hand.
 
 # [How to complete the assignment](https://github.com/vvv-school/vvv-school.github.io/blob/master/instructions/how-to-complete-assignments.md)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This second tutorial will guide you through integrating YARP with OpenCV while g
 
 The task at hand is to correctly detect a red ball from images from a dataset streamed through a port.
 
-The dataset is currently available on the provided virtual machine. Otherwise it can be downloaded following these simple steps:
+The dataset is currently available on the provided virtual environment. Otherwise, it can be downloaded following these simple steps:
 ```sh
 cd $DATASETS_PATH
 $ wget http://www.icub.org/download/software/datasetplayer-demo/testData_20120803_095402.zip

--- a/smoke-test/fixtures/fixture.xml
+++ b/smoke-test/fixtures/fixture.xml
@@ -6,6 +6,10 @@
         <author email="vadim.tikhanoff@iit.it">Vadim Tikhanoff</author>
     </authors>
     <module>
+        <name>yarpdataplayer</name>
+        <node>testnode</node>
+    </module>
+    <module>
         <name>yarp-opencv</name>
         <node>testnode</node>
     </module>
@@ -19,11 +23,6 @@
         <node>testnode</node>
         <parameters>--name /mask --x 300 --y 0 --RefreshTime 33 </parameters>
     </module>
-    <connection>
-        <from>/icub/camcalib/left/out</from>
-        <to>/yarp-opencv/image:i</to>
-        <protocol>tcp</protocol>
-    </connection>
     <connection>
         <from>/yarp-opencv/image:o</from>
         <to>/output</to>

--- a/smoke-test/post-test.sh
+++ b/smoke-test/post-test.sh
@@ -5,13 +5,3 @@
 # CopyPolicy: Released under the terms of the GNU GPL v3.0.
 
 # Put here those instructions we need to execute after having run the test
-
-echo "stop" | yarp rpc /yarpdataplayer/rpc:i
-echo "quit" | yarp rpc /yarpdataplayer/rpc:i
-
-if [ $stop_yarpserver == "yes" ]; then 
-    echo "stop_yarpserver == yes killing it "
-    killall -9 yarpserver 
-fi
-
-unset stop_yarpserver

--- a/smoke-test/pre-test.sh
+++ b/smoke-test/pre-test.sh
@@ -5,20 +5,3 @@
 # CopyPolicy: Released under the terms of the GNU GPL v3.0.
 
 # Put here those instructions we need to execute before running the test
-
-yarp where
-if [ $? -eq 0 ]; then
-   export stop_yarpserver="no"
-   echo "stop_yarpserver == no"
-else
-   export stop_yarpserver="yes"
-   echo "stop_yarpserver == yes"
-   yarpserver --write &
-   sleep 1
-fi
-
-yarpdataplayer &
-sleep 3
-#echo "load $ROBOT_CODE/datasets/testData_20120803_095402" | yarp rpc /yarpdataplayer/rpc:i
-echo "load /workspace/datasets/testData_20120803_095402" | yarp rpc /yarpdataplayer/rpc:i
-echo "play" | yarp rpc /yarpdataplayer/rpc:i

--- a/smoke-test/test.xml
+++ b/smoke-test/test.xml
@@ -4,5 +4,5 @@
     <description>Testing the tutorial on tracking with yarp+opencv </description>
     <fixture param="--fixture fixture.xml"> yarpmanager </fixture>
 
-    <test type="dll"> TestTutorialYarpOpencv </test>
+    <test type="dll" param="--dataset testData_20120803_095402"> TestTutorialYarpOpencv </test>
 </suite>


### PR DESCRIPTION
This PR proposes the following changes:
- Use of the `vvv-school` image instead of the `easy-peasy-robotics` one as it should be for tutorials and assignments contained in this org; in detail, the latter has been provided only to address the web20 assignment as well as the model alignment task.
- Harmonize the use of the env variable, which is now called `DATASETS_PATH` and will be correctly handled both in the VM and docker images. To this end, have a look at https://github.com/vvv-school/vvv-school.github.io/commit/55175a77d551996542a089bcbd9f54eb15e452cb (the corresponding image is being built right now).
- Call `yarpdataplayer` from the `yarpmanager` fixture straight away in the case of the smoke test. This is the preferred way as the smoke test handles the `yarpserver` too.

Tests are successful ✔